### PR TITLE
add an option to apply style conditionnaly

### DIFF
--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -46,6 +46,8 @@ function s:LinuxConfigure()
     endif
 endfunction
 
+command! SetLinuxStyle call s:SetLinuxStyle()
+
 function! s:SetLinuxStyle()
     call s:LinuxFormatting()
     call s:LinuxKeywords()

--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -42,10 +42,14 @@ function s:LinuxConfigure()
     endif
 
     if apply_style
-        call s:LinuxFormatting()
-        call s:LinuxKeywords()
-        call s:LinuxHighlighting()
+        call s:SetLinuxStyle()
     endif
+endfunction
+
+function! s:SetLinuxStyle()
+    call s:LinuxFormatting()
+    call s:LinuxKeywords()
+    call s:LinuxHighlighting()
 endfunction
 
 function s:LinuxFormatting()

--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -5,6 +5,13 @@
 " This script is inspired from an article written by Bart:
 " http://www.jukie.net/bart/blog/vim-and-linux-coding-style
 " and various user comments.
+"
+" For those who want to apply these options conditionnaly, you can define an
+" array of patterns in your vimrc and these options will be applied only if
+" the buffer's path matches one of the pattern. In the following example,
+" options will be applied only if "/linux/" or "/kernel" is in buffer's path.
+"
+"   let g:linuxsty_patterns = [ "/linux/", "/kernel/" ]
 
 if exists("g:loaded_linuxsty")
     finish
@@ -16,11 +23,30 @@ set wildignore+=*.ko,*.mod.c,*.order,modules.builtin
 augroup linuxsty
     autocmd!
 
-    autocmd FileType c,cpp call s:LinuxFormatting()
-    autocmd FileType c,cpp call s:LinuxKeywords()
-    autocmd FileType c,cpp call s:LinuxHighlighting()
+    autocmd FileType c,cpp call s:LinuxConfigure()
     autocmd FileType diff,kconfig setlocal tabstop=8
 augroup END
+
+function s:LinuxConfigure()
+    let apply_style = 0
+
+    if exists("g:linuxsty_patterns")
+        let path = expand('%:p')
+        for p in g:linuxsty_patterns
+            if path =~ p
+                let apply_style = 1
+            endif
+        endfor
+    else
+        let apply_style = 1
+    endif
+
+    if apply_style
+        call s:LinuxFormatting()
+        call s:LinuxKeywords()
+        call s:LinuxHighlighting()
+    endif
+endfunction
 
 function s:LinuxFormatting()
     setlocal tabstop=8


### PR DESCRIPTION
Currently the kernel coding style applies to every buffers which has the
c or cpp filetype. Some users might want a finer control and apply this
style only to their kernels.

This commit changes the way the style is applied. Users can now define a
"g:linuxsty_patterns" array in their vimrc and the style will be applied
only if the buffer's path matches one of the pattern.