### PR TITLE
highlight 80 char limit

### DIFF
--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -64,6 +64,7 @@ function s:LinuxFormatting()
 
     setlocal cindent
     setlocal cinoptions=:0,l1,t0,g0,(0
+    set cc=80
 endfunction
 
 function s:LinuxKeywords()


### PR DESCRIPTION
Is it interesting to have this red line marking the 80 character limit? python-mode does the same thing.

![linuxsty-80-lim](https://cloud.githubusercontent.com/assets/8574092/19216190/8ac564f0-8d80-11e6-8f72-7b8ce345dd00.png)
