### PR TITLE
fix bracket matching mess-up caused by highlights

### DIFF
--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -78,7 +78,7 @@ function s:LinuxHighlighting()
     highlight default link LinuxError ErrorMsg
 
     syn match LinuxError / \+\ze\t/     " spaces before tab
-    syn match LinuxError /\%81v.\+/     " virtual column 81 and more
+    syn match LinuxError /\%>80v[^()\{\}\[\]<>]\+/ " virtual column 81 and more
 
     " Highlight trailing whitespace, unless we're in insert mode and the
     " cursor's placed right after the whitespace. This prevents us from having


### PR DESCRIPTION
Highlighting characters `[]{}<>()` messes up the brace matching and syntax folds (#7).
This PR excludes the above characters from the highlighting.
It looks not good since not all characters on the right of the 80-char-line are highlighted, but I think that's a trade-off for functionality (syntax folds).