### PR TITLE
Add exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ only projects under /usr/src/ and /linux with the following:
 
     let g:linuxsty_patterns = [ "/usr/src/", "/linux" ]
 
+Exclusion patterns can be also be applied. The following example would
+exclude anything that had "/foo/" in the path, even if it would match
+something in linuxsty_patterns
+
+    let g:linuxsty_exclude_patterns = [ "/foo/" ]
+
 If you want to enable the coding style on demand without checking the filetype, 
 you can use the :LinuxCodingStyle command. For instance, you can map it with 
 the following in your vimrc:

--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -12,6 +12,12 @@
 " options will be applied only if "/linux/" or "/kernel" is in buffer's path.
 "
 "   let g:linuxsty_patterns = [ "/linux/", "/kernel/" ]
+"
+" Exclusion patterns can be also be applied. The following example would
+" exclude anything that had "/foo/" in the path, even if it would match
+" something in linuxsty_patterns
+"
+"   let g:linuxsty_exclude_patterns = [ "/foo/" ]
 
 if exists("g:loaded_linuxsty")
     finish
@@ -42,6 +48,16 @@ function s:LinuxConfigure()
         endfor
     else
         let apply_style = 1
+    endif
+
+    if exists("g:linuxsty_exclude_patterns")
+        let path = expand('%:p')
+        for p in g:linuxsty_exclude_patterns
+            if path =~ p
+                let apply_style = 0
+                break
+            endif
+        endfor
     endif
 
     if apply_style


### PR DESCRIPTION
Exclusions can be used to exclude the style from being applied to paths,
even if they would match linuxsty_patterns