### PR TITLE
Avoid space indentation in .rst files

### DIFF
--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -25,6 +25,7 @@ augroup linuxsty
 
     autocmd FileType c,cpp call s:LinuxConfigure()
     autocmd FileType diff setlocal ts=8
+    autocmd FileType rst setlocal ts=8 sw=8 sts=8 noet
     autocmd FileType kconfig setlocal ts=8 sw=8 sts=8 noet
     autocmd FileType dts setlocal ts=8 sw=8 sts=8 noet
 augroup END


### PR DESCRIPTION
Right now when .rst files (help files) are edited the indentation is
done with spaces not with tabs as it should be.

Add .rst to the "linuxsty" group to fix this.

Signed-off-by: Frank A. Cancio Bello <frank@generalsoftwareinc.com>